### PR TITLE
Add support for all NodaTime 3 types

### DIFF
--- a/src/MicroElements.AutoFixture.NodaTime/AbstractDateTimeOffsetBasedSpecimenBuilder.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/AbstractDateTimeOffsetBasedSpecimenBuilder.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// Abstract generic specimen builder, used to provide a DateTimeOffset to derived builders.
+    /// </summary>
+    /// <typeparam name="T">The type to create.</typeparam>
+    public abstract class AbstractDateTimeOffsetBasedSpecimenBuilder<T> : ISpecimenBuilder
+    {
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(T).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var dateTime = context.Create<DateTimeOffset>();
+            return this.CreateFromDateTimeOffset(dateTime, context);
+        }
+
+        /// <summary>
+        /// Implement to create a T specimen from a DateTimeOffset.
+        /// </summary>
+        /// <param name="dateTimeOffset">The DateTimeOffset value to use for specimen building.</param>
+        /// <returns>The generated value.</returns>
+        /// <param name="context"></param>
+        protected abstract T CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context);
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/AnnualDateGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/AnnualDateGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="AnnualDate"/>.
+    /// </summary>
+    public class AnnualDateGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<AnnualDate>
+    {
+        /// <inheritdoc/>
+        protected override AnnualDate CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => new AnnualDate(dateTimeOffset.Month, dateTimeOffset.Day);
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/DateIntervalGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/DateIntervalGenerator.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="DateInterval"/>.
+    /// </summary>
+    public class DateIntervalGenerator : ISpecimenBuilder
+    {
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(DateInterval).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var localDateBuilder = new LocalDateGenerator();
+            var periodBuilder = new PeriodGenerator();
+
+            var localDate = (LocalDate)localDateBuilder.Create(typeof(LocalDate), context);
+            var period = (Period)periodBuilder.Create(typeof(Period), context);
+
+            return new DateInterval(localDate, localDate.PlusDays(period.Days));
+        }
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/DateTimeZoneGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/DateTimeZoneGenerator.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="DateTimeZone"/>.
+    /// </summary>
+    public class DateTimeZoneGenerator : ISpecimenBuilder
+    {
+        private static IDateTimeZoneProvider dateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
+
+        /// <summary>
+        /// Gets or sets the <see cref="IDateTimeZoneProvider"/> used for creating <see cref="DateTimeZone"/> specimens.
+        /// </summary>
+        public static IDateTimeZoneProvider DateTimeZoneProvider
+        {
+            get { return dateTimeZoneProvider; }
+            set { dateTimeZoneProvider = value ?? throw new ArgumentNullException(nameof(value)); }
+        }
+
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(DateTimeZone).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var zones = DateTimeZoneProvider.Ids;
+
+            return DateTimeZoneProvider[zones[new Random().Next(0, zones.Count - 1)]];
+        }
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/DurationGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/DurationGenerator.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="Duration"/>.
+    /// </summary>
+    public class DurationGenerator : ISpecimenBuilder
+    {
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(Duration).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            return Duration.FromHours(context.Create<int>())
+                .Plus(Duration.FromSeconds(context.Create<long>()))
+                .Plus(Duration.FromMilliseconds(context.Create<long>()));
+        }
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/InstantGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/InstantGenerator.cs
@@ -10,22 +10,10 @@ namespace MicroElements.AutoFixture.NodaTime
     /// <summary>
     /// AutoFixture generator for <see cref="Instant"/>.
     /// </summary>
-    public class InstantGenerator : ISpecimenBuilder
+    public class InstantGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<Instant>
     {
-        /// <inheritdoc />
-        public object Create(object request, ISpecimenContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (!typeof(Instant).Equals(request))
-            {
-                return new NoSpecimen();
-            }
-
-            return Instant.FromDateTimeUtc(DateTime.Now.ToUniversalTime());
-        }
+        /// <inheritdoc/>
+        protected override Instant CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => Instant.FromDateTimeOffset(dateTimeOffset);
     }
 }

--- a/src/MicroElements.AutoFixture.NodaTime/IntervalGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/IntervalGenerator.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="Interval"/>.
+    /// </summary>
+    public class IntervalGenerator : ISpecimenBuilder
+    {
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(Interval).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var instantBuilder = new InstantGenerator();
+            var instant1 = (Instant)instantBuilder.Create(typeof(Instant), context);
+            var instant2 = (Instant)instantBuilder.Create(typeof(Instant), context);
+
+            if (instant2 >= instant1)
+            {
+                return new Interval(instant1, instant2);
+            }
+
+            return new Interval(instant2, instant1);
+        }
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/LocalDateTimeGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/LocalDateTimeGenerator.cs
@@ -10,22 +10,10 @@ namespace MicroElements.AutoFixture.NodaTime
     /// <summary>
     /// AutoFixture generator for <see cref="LocalDateTime"/>.
     /// </summary>
-    public class LocalDateTimeGenerator : ISpecimenBuilder
+    public class LocalDateTimeGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<LocalDateTime>
     {
-        /// <inheritdoc />
-        public object Create(object request, ISpecimenContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (!typeof(LocalDateTime).Equals(request))
-            {
-                return new NoSpecimen();
-            }
-
-            return LocalDateTime.FromDateTime(DateTime.Now);
-        }
+        /// <inheritdoc/>
+        protected override LocalDateTime CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => LocalDateTime.FromDateTime(dateTimeOffset.DateTime);
     }
 }

--- a/src/MicroElements.AutoFixture.NodaTime/LocalTimeGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/LocalTimeGenerator.cs
@@ -10,22 +10,10 @@ namespace MicroElements.AutoFixture.NodaTime
     /// <summary>
     /// AutoFixture generator for <see cref="LocalTime"/>.
     /// </summary>
-    public class LocalTimeGenerator : ISpecimenBuilder
+    public class LocalTimeGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<LocalTime>
     {
-        /// <inheritdoc />
-        public object Create(object request, ISpecimenContext context)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            if (!typeof(LocalTime).Equals(request))
-            {
-                return new NoSpecimen();
-            }
-
-            return LocalTime.FromTicksSinceMidnight(DateTime.Now.TimeOfDay.Ticks);
-        }
+        /// <inheritdoc/>
+        protected override LocalTime CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => LocalTime.FromTicksSinceMidnight(dateTimeOffset.TimeOfDay.Ticks);
     }
 }

--- a/src/MicroElements.AutoFixture.NodaTime/MicroElements.AutoFixture.NodaTime.csproj
+++ b/src/MicroElements.AutoFixture.NodaTime/MicroElements.AutoFixture.NodaTime.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NodaTime" Version="2.4.7" />
+    <PackageReference Include="NodaTime" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MicroElements.AutoFixture.NodaTime/NodaTimeCustomization.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/NodaTimeCustomization.cs
@@ -16,7 +16,28 @@ namespace MicroElements.AutoFixture.NodaTime
             fixture.Customizations.Add(new LocalDateGenerator());
             fixture.Customizations.Add(new LocalTimeGenerator());
             fixture.Customizations.Add(new LocalDateTimeGenerator());
+
+            fixture.Customizations.Add(new OffsetDateGenerator());
+            fixture.Customizations.Add(new OffsetTimeGenerator());
+            fixture.Customizations.Add(new OffsetDateTimeGenerator());
+
             fixture.Customizations.Add(new InstantGenerator());
+
+            fixture.Customizations.Add(new YearMonthGenerator());
+
+            fixture.Customizations.Add(new AnnualDateGenerator());
+
+            fixture.Customizations.Add(new DateIntervalGenerator());
+
+            fixture.Customizations.Add(new IntervalGenerator());
+
+            fixture.Customizations.Add(new PeriodGenerator());
+
+            fixture.Customizations.Add(new DurationGenerator());
+
+            fixture.Customizations.Add(new DateTimeZoneGenerator());
+
+            fixture.Customizations.Add(new ZonedDateTimeGenerator());
         }
     }
 }

--- a/src/MicroElements.AutoFixture.NodaTime/OffsetDateGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/OffsetDateGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="OffsetDate"/>.
+    /// </summary>
+    public class OffsetDateGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<OffsetDate>
+    {
+        /// <inheritdoc/>
+        protected override OffsetDate CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => OffsetDateTime.FromDateTimeOffset(dateTimeOffset).ToOffsetDate();
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/OffsetDateTimeGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/OffsetDateTimeGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="OffsetDateTime"/>.
+    /// </summary>
+    public class OffsetDateTimeGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<OffsetDateTime>
+    {
+        /// <inheritdoc/>
+        protected override OffsetDateTime CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => OffsetDateTime.FromDateTimeOffset(dateTimeOffset);
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/OffsetGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/OffsetGenerator.cs
@@ -7,13 +7,14 @@ using NodaTime;
 
 namespace MicroElements.AutoFixture.NodaTime
 {
+
     /// <summary>
-    /// AutoFixture generator for <see cref="LocalDate"/>.
+    /// AutoFixture generator for <see cref="Offset"/>.
     /// </summary>
-    public class LocalDateGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<LocalDate>
+    public class OffsetGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<Offset>
     {
         /// <inheritdoc/>
-        protected override LocalDate CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
-            => LocalDate.FromDateTime(dateTimeOffset.DateTime);
+        protected override Offset CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => Offset.FromTimeSpan(dateTimeOffset.Offset);
     }
 }

--- a/src/MicroElements.AutoFixture.NodaTime/OffsetTimeGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/OffsetTimeGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="OffsetTime"/>.
+    /// </summary>
+    public class OffsetTimeGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<OffsetTime>
+    {
+        /// <inheritdoc/>
+        protected override OffsetTime CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => OffsetDateTime.FromDateTimeOffset(dateTimeOffset).ToOffsetTime();
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/PeriodGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/PeriodGenerator.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="AnnualDate"/>.
+    /// </summary>
+    public class PeriodGenerator : ISpecimenBuilder
+    {
+        /// <inheritdoc/>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!typeof(Period).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            return Period.FromSeconds(context.Create<long>());
+        }
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/YearMonthGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/YearMonthGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="AnnualDate"/>.
+    /// </summary>
+    public class YearMonthGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<YearMonth>
+    {
+        /// <inheritdoc/>
+        protected override YearMonth CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => new YearMonth(dateTimeOffset.Year, dateTimeOffset.Month);
+    }
+}

--- a/src/MicroElements.AutoFixture.NodaTime/ZonedDateTimeGenerator.cs
+++ b/src/MicroElements.AutoFixture.NodaTime/ZonedDateTimeGenerator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using AutoFixture.Kernel;
+using NodaTime;
+
+namespace MicroElements.AutoFixture.NodaTime
+{
+    /// <summary>
+    /// AutoFixture generator for <see cref="ZonedDateTime"/>.
+    /// </summary>
+    public class ZonedDateTimeGenerator : AbstractDateTimeOffsetBasedSpecimenBuilder<ZonedDateTime>
+    {
+        /// <inheritdoc/>
+        protected override ZonedDateTime CreateFromDateTimeOffset(DateTimeOffset dateTimeOffset, ISpecimenContext context)
+            => OffsetDateTime.FromDateTimeOffset(dateTimeOffset)
+            .InZone((DateTimeZone)new DateTimeZoneGenerator().Create(typeof(DateTimeZone), context));
+    }
+}

--- a/test/MicroElements.AutoFixture.NodaTime.Tests/MicroElements.AutoFixture.NodaTime.Tests.csproj
+++ b/test/MicroElements.AutoFixture.NodaTime.Tests/MicroElements.AutoFixture.NodaTime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/MicroElements.AutoFixture.NodaTime.Tests/NodaTimeCustomizationTest.cs
+++ b/test/MicroElements.AutoFixture.NodaTime.Tests/NodaTimeCustomizationTest.cs
@@ -1,3 +1,4 @@
+using System;
 using AutoFixture;
 using FluentAssertions;
 using NodaTime;
@@ -41,6 +42,115 @@ namespace MicroElements.AutoFixture.NodaTime.Tests
                 .Customize(new NodaTimeCustomization())
                 .Create<Instant>()
                 .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void OffsetDateGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<OffsetDate>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void OffsetTimeGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<OffsetTime>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void OffsetDateTimeGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<OffsetDateTime>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void AnnualDateGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<AnnualDate>()
+                .Should().NotBe(default);
+        }
+
+
+        [Fact]
+        public void YearMonthGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<YearMonth>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void DurationGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<Duration>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void PeriodGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<Period>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void DateTimeZoneGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<DateTimeZone>()
+                .Should().NotBe(default);
+        }
+
+        [Fact]
+        public void DateIntervalGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<DateInterval>()
+                .Should().NotBeNull();
+        }
+
+        [Fact]
+        public void IntervalGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<Interval>()
+                .Should().NotBeNull();
+        }
+
+        [Fact]
+        public void OffsetGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<Offset>()
+                .Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ZonedDateTimeGenerator()
+        {
+            new Fixture()
+                .Customize(new NodaTimeCustomization())
+                .Create<ZonedDateTime>()
+                .Should().NotBeNull();
         }
     }
 }


### PR DESCRIPTION
Just added support for all (?) NodaTime 3 types. Most things are based on creating a DateTimeOffset, to begin with. Convenient, but not necessarily the best way to get customization support.